### PR TITLE
Controller Remaping Bug Fix

### DIFF
--- a/Assets/Scripts/Input/InputManager.cs
+++ b/Assets/Scripts/Input/InputManager.cs
@@ -78,9 +78,8 @@ public class InputManager : MonoBehaviour {
         {PlayerAxis.UI_Horizontal, "KeyboardX"},
         {PlayerAxis.UI_Vertical, "KeyboardY"},
     };
-    void Awake()
-    {
-        
+    void Start()
+    {       
         playerActions[0].keyboardKey = KeyCode.Space;
         playerActions[0].xboxKey = KeyCode.Joystick1Button0;
         playerActions[1].keyboardKey = KeyCode.LeftShift;

--- a/Assets/Scripts/UI/XboxRemap.cs
+++ b/Assets/Scripts/UI/XboxRemap.cs
@@ -68,13 +68,16 @@ public class XboxRemap : MonoBehaviour
                 return;
             }
         }
-        PlayerAction actn = InputManager.playerButtons[action];
-        actn.xboxKey = passed;
-        InputManager.playerButtons[action] = actn;
-        xboxCodes.Remove(keyName);
-        keyName = passed.ToString();
-        xboxCodes.Add(keyName);
-        GetComponentInChildren<Text>().text = keyName;
+        if (InputManager.playerXboxButtons.ContainsKey(passed))
+        {
+            PlayerAction actn = InputManager.playerButtons[action];
+            actn.xboxKey = passed;
+            InputManager.playerButtons[action] = actn;
+            xboxCodes.Remove(keyName);
+            keyName = passed.ToString();
+            xboxCodes.Add(keyName);
+            GetComponentInChildren<Text>().text = keyName;
+        }        
     }
     public IEnumerator timerRemaping()
     {


### PR DESCRIPTION
Fixed A bug that allowed the player to be able to remap noncontroller inputs into the controller and would then cause the buttons on the rempaing UI to not load properly and as a result lock the player in the settings screen